### PR TITLE
Compat PR for BiomeRandomizer

### DIFF
--- a/src/Scripts/RewardPresentation.lua
+++ b/src/Scripts/RewardPresentation.lua
@@ -2,7 +2,7 @@
 -- For Hades Tartartus doors, we use the original Hades backing art, so we set ReUseIds which prevents the Hades II backing from being created
 modutil.mod.Path.Wrap("CreateDoorRewardPreview", function(base, exitDoor, chosenRewardType, chosenLootName, index, args)
 	args = args or {}
-
+	game.CurrentRun.CurrentRoom.ModsNikkelMHadesBiomesDestroyIdsOnDeath = game.CurrentRun.CurrentRoom.ModsNikkelMHadesBiomesDestroyIdsOnDeath or {}
 	if not args.ReUseIds and (exitDoor.Name == "TartarusDoor03b" or exitDoor.Name == "AsphodelBoat01b") then
 		local room = exitDoor.Room
 		chosenRewardType = chosenRewardType or room.ChosenRewardType


### PR DESCRIPTION
Init `CurrentRun.CurrentRoom.ModsNikkelMHadesBiomesDestroyIdsOnDeath` in CreateDoorRewardPreview.

This is not initialized if a random zag's journey biome is loaded.