### PR TITLE
Fix Pom Porridge only increasing boons by one level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 Other fixes and improvements:
 - Balancing: Trap damage now scales in Dream Dives.
 - Fixed: Rewards from Shrines of Hermes and Icarus' "Supply Chain" boon can be delivered after defeating Charon, which softlocks the player if picked up.
+- Fixed: Eurydice's "Pom Porridge" only upgrades boons by one instead of two levels (fix by zerp).
 - Fixed: In rare cases, the game may crash after Melinoë exits "Unseen Ire" while an enemy is performing a certain type of attack.
 - Fixed: If the Tiny Vermin in Styx is met before meeting King Vermin in Oceanus, the game crashes.
 - Fixed: The Tiny Vermin is damaged by Medea's "Suffering on Sight" boon.

--- a/src/Scripts/NPCLogic.lua
+++ b/src/Scripts/NPCLogic.lua
@@ -294,21 +294,21 @@ function mod.ModsNikkelMHadesBiomesEurydiceBuff(args, source)
 	mod.ModsNikkelMHadesBiomesEurydicePostBuffPresentation(source, args)
 end
 
-function mod.ModsNikkelMHadesBiomesEurydiceBuffMegaPom(args, source)
+-- Fixed version of AddStackToTraits(), which only ever adds one level regardless of the passed args.NumStacks
+function mod.ModsNikkelMHadesBiomesAddStackToTraits(source, args)
 	args = args or {}
-	mod.ModsNikkelMHadesBiomesEurydicePreBuffPresentation(source, args)
 	local numTraits = args.NumTraits or 1
 	local numStacks = args.NumStacks or 1
 
-	local upgradableTraits = game.GetAllUpgradeableGodTraits( numStacks )
+	local upgradableTraits = game.GetAllUpgradeableGodTraits(numStacks)
 	local upgradedTraits = {}
 
-	while numTraits > 0 and not game.IsEmpty( upgradableTraits ) do
-		local name = game.GetRandomKey( upgradableTraits )
+	while numTraits > 0 and not game.IsEmpty(upgradableTraits) do
+		local name = game.GetRandomKey(upgradableTraits) or ""
 		upgradedTraits[name] = true
-		local traitData = game.GetHeroTrait(name)
+		local traitData = game.GetHeroTrait(name) or {}
 		if not traitData.BlockStacking then
-			game.IncreaseTraitLevel( traitData, numStacks )
+			game.IncreaseTraitLevel(traitData, numStacks)
 		end
 		numTraits = numTraits - 1
 		upgradableTraits[name] = nil
@@ -316,16 +316,15 @@ function mod.ModsNikkelMHadesBiomesEurydiceBuffMegaPom(args, source)
 
 	game.UpdateHeroTraitDictionary()
 
-	for i, traitData in ipairs( game.CurrentRun.Hero.Traits ) do
+	for i, traitData in ipairs(game.CurrentRun.Hero.Traits) do
 		if upgradedTraits[traitData.Name] then
 			game.wait(0.1)
-			game.TraitUIUpdateText( traitData )
+			game.TraitUIUpdateText(traitData)
 		end
 	end
 	if not args.Silent then
-		game.thread( game.IncreasedTraitLevelPresentation, upgradedTraits, numStacks )
+		game.thread(game.IncreasedTraitLevelPresentation, upgradedTraits, numStacks)
 	end
-	mod.ModsNikkelMHadesBiomesEurydicePostBuffPresentation(source, args)
 end
 
 function mod.ModsNikkelMHadesBiomesEurydicePreBuffPresentation(source, args)

--- a/src/Scripts/NPCLogic.lua
+++ b/src/Scripts/NPCLogic.lua
@@ -294,6 +294,40 @@ function mod.ModsNikkelMHadesBiomesEurydiceBuff(args, source)
 	mod.ModsNikkelMHadesBiomesEurydicePostBuffPresentation(source, args)
 end
 
+function mod.ModsNikkelMHadesBiomesEurydiceBuffMegaPom(args, source)
+	args = args or {}
+	mod.ModsNikkelMHadesBiomesEurydicePreBuffPresentation(source, args)
+	local numTraits = args.NumTraits or 1
+	local numStacks = args.NumStacks or 1
+
+	local upgradableTraits = game.GetAllUpgradeableGodTraits( numStacks )
+	local upgradedTraits = {}
+
+	while numTraits > 0 and not game.IsEmpty( upgradableTraits ) do
+		local name = game.GetRandomKey( upgradableTraits )
+		upgradedTraits[name] = true
+		local traitData = game.GetHeroTrait(name)
+		if not traitData.BlockStacking then
+			game.IncreaseTraitLevel( traitData, numStacks )
+		end
+		numTraits = numTraits - 1
+		upgradableTraits[name] = nil
+	end
+
+	game.UpdateHeroTraitDictionary()
+
+	for i, traitData in ipairs( game.CurrentRun.Hero.Traits ) do
+		if upgradedTraits[traitData.Name] then
+			game.wait(0.1)
+			game.TraitUIUpdateText( traitData )
+		end
+	end
+	if not args.Silent then
+		game.thread( game.IncreasedTraitLevelPresentation, upgradedTraits, numStacks )
+	end
+	mod.ModsNikkelMHadesBiomesEurydicePostBuffPresentation(source, args)
+end
+
 function mod.ModsNikkelMHadesBiomesEurydicePreBuffPresentation(source, args)
 	PlaySound({ Name = "/Leftovers/Menu Sounds/EmoteExcitement" })
 	game.wait(1.6)

--- a/src/Scripts/TraitDataNPCs.lua
+++ b/src/Scripts/TraitDataNPCs.lua
@@ -349,7 +349,7 @@ local newTraitData = {
 		},
 	},
 	ModsNikkelMHadesBiomesBuffMegaPom = {
-		InheritFrom = { "ModsNikkelMHadesBiomesBaseEurydice", "ModsNikkelMHadesBiomesBuffSlottedBoonRarity" },
+		InheritFrom = { "ModsNikkelMHadesBiomesBaseEurydice" },
 		Icon = "Boon_Eurydice_02",
 		RarityLevels = {
 			Common = { Multiplier = 1 },
@@ -364,8 +364,9 @@ local newTraitData = {
 		GameStateRequirements = {
 			NamedRequirements = { "StackUpgradeLegal", },
 		},
+		BoonInfoIgnoreRequirements = true,
+		AcquireFunctionName = _PLUGIN.guid .. "." .. "ModsNikkelMHadesBiomesEurydiceBuffMegaPom",
 		AcquireFunctionArgs = {
-			FunctionName = "AddStackToTraits",
 			NumTraits = 3,
 			NumStacks = 2,
 			ReportValues = {

--- a/src/Scripts/TraitDataNPCs.lua
+++ b/src/Scripts/TraitDataNPCs.lua
@@ -365,8 +365,9 @@ local newTraitData = {
 			NamedRequirements = { "StackUpgradeLegal", },
 		},
 		BoonInfoIgnoreRequirements = true,
-		AcquireFunctionName = _PLUGIN.guid .. "." .. "ModsNikkelMHadesBiomesEurydiceBuffMegaPom",
+		AcquireFunctionName = _PLUGIN.guid .. "." .. "ModsNikkelMHadesBiomesEurydiceBuff",
 		AcquireFunctionArgs = {
+			FunctionName = _PLUGIN.guid .. "." .. "ModsNikkelMHadesBiomesAddStackToTraits",
 			NumTraits = 3,
 			NumStacks = 2,
 			ReportValues = {

--- a/src/Scripts/TraitDataNPCs.lua
+++ b/src/Scripts/TraitDataNPCs.lua
@@ -349,7 +349,7 @@ local newTraitData = {
 		},
 	},
 	ModsNikkelMHadesBiomesBuffMegaPom = {
-		InheritFrom = { "ModsNikkelMHadesBiomesBaseEurydice" },
+		InheritFrom = { "ModsNikkelMHadesBiomesBaseEurydice", "ModsNikkelMHadesBiomesBuffSlottedBoonRarity" },
 		Icon = "Boon_Eurydice_02",
 		RarityLevels = {
 			Common = { Multiplier = 1 },
@@ -364,8 +364,6 @@ local newTraitData = {
 		GameStateRequirements = {
 			NamedRequirements = { "StackUpgradeLegal", },
 		},
-		BoonInfoIgnoreRequirements = true,
-		AcquireFunctionName = _PLUGIN.guid .. "." .. "ModsNikkelMHadesBiomesEurydiceBuff",
 		AcquireFunctionArgs = {
 			FunctionName = _PLUGIN.guid .. "." .. "ModsNikkelMHadesBiomesAddStackToTraits",
 			NumTraits = 3,


### PR DESCRIPTION
`AddStackToTraits` is broken and always upgrades the boon by only 1 level and stuff like Kings Ransom/Bridal Glow use the `IncreaseTraitLevel` function directly.

The new function added is essentially a "fixed" version of `AddStackToTraits`.