### PR TITLE
Check screen is InventoryScreen before configuring badge data

### DIFF
--- a/src/Scripts/ResourceLogic_Late.lua
+++ b/src/Scripts/ResourceLogic_Late.lua
@@ -2,14 +2,15 @@ modutil.mod.Path.Context.Wrap.Static("OpenInventoryScreen", function(origArgs)
 	-- Show the modded badges in the inventory (left and right of the vanilla badge)
 	modutil.mod.Path.Wrap("CreateScreenFromData", function(base, screen, componentData, args)
 		base(screen, componentData, args)
-
-		local components = screen.Components
-		if game.GameState.ModsNikkelMHadesBiomesBadgeRank ~= nil then
-			local badgeData = game.ModsNikkelMHadesBiomesBadgeData
-					[game.ModsNikkelMHadesBiomesBadgeOrderData[game.GameState.ModsNikkelMHadesBiomesBadgeRank]]
-			if badgeData ~= nil then
-				SetAnimation({ DestinationId = components.ModsNikkelMHadesBiomesBadgeRankIconLeft.Id, Name = badgeData.Icon })
-				SetAnimation({ DestinationId = components.ModsNikkelMHadesBiomesBadgeRankIconRight.Id, Name = badgeData.Icon })
+		if screen.Name == "InventoryScreen" then
+			local components = screen.Components
+			if game.GameState.ModsNikkelMHadesBiomesBadgeRank ~= nil then
+				local badgeData = game.ModsNikkelMHadesBiomesBadgeData
+						[game.ModsNikkelMHadesBiomesBadgeOrderData[game.GameState.ModsNikkelMHadesBiomesBadgeRank]]
+				if badgeData ~= nil then
+					SetAnimation({ DestinationId = components.ModsNikkelMHadesBiomesBadgeRankIconLeft.Id, Name = badgeData.Icon })
+					SetAnimation({ DestinationId = components.ModsNikkelMHadesBiomesBadgeRankIconRight.Id, Name = badgeData.Icon })
+				end
 			end
 		end
 	end)


### PR DESCRIPTION
Fixes crash on picking a Path of Stars in PonyMenu.

```
[17:52:13.3125714][ERROR/log_write.hpp:75] [ERR] [Engine.Native\Code\Helpers\LuaExt.cpp:393] Script error: 

D:\SteamLibrary\steamapps\common\Hades II\Content\Scripts\Main.lua:169: ...s\NikkelM-Zagreus_Journey/Scripts/ResourceLogic_Late.lua:11: attempt to index field 'ModsNikkelMHadesBiomesBadgeRankIconLeft' (a nil value)

[17:52:13.3125788][INFO/log_write.hpp:75] [INFO] [Engine.Native\Code\Audio\AudioManager.cpp:2556] PauseAllGameSound
[17:52:13.3125851][ERROR/log_write.hpp:75] [ERR] [Engine.Native\Windows\Code\Program.cpp:966] Assert: File = Main.lua, Line = 169, Condition = Script Error, Message =  attempt to index field 'ModsNikkelMHadesBiomesBadgeRankIconLeft' (a nil value)



Lua Stack Trace: 

D:\SteamLibrary\steamapps\common\Hades II\Content\Scripts\Main.lua:169: ...s\NikkelM-Zagreus_Journey/Scripts/ResourceLogic_Late.lua:11: attempt to index field 'ModsNikkelMHadesBiomesBadgeRankIconLeft' (a nil value),
```